### PR TITLE
feature/terminal-click-focus: Fix terminal bottom-left click not focusing input - move from formEl to terminalPane (- input, button, and other text ("a.txt"))

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -350,8 +350,9 @@
 		});
 	}
 
-	formEl.addEventListener('click', function (event) {
-		if (event.target !== inputEl) {
+	terminalPane.addEventListener('click', function (event) {
+		var tag = event.target.tagName.toLowerCase();
+		if (tag !== 'input' && tag !== 'button' && tag !== 'a') {
 			inputEl.focus();
 		}
 	});


### PR DESCRIPTION
Fix terminal bottom-left click not focusing input